### PR TITLE
Fix the problem where select os step show empty list

### DIFF
--- a/src/menu/instanceMultiStep.ts
+++ b/src/menu/instanceMultiStep.ts
@@ -119,8 +119,24 @@ export async function createInstanceMultiStep(
             return; // 提前退出 updateView
           }
           items.push(backItem); // 添加返回按钮
+
+          // 修复：确保 os 是数组，并且有数据
+          const osList = Array.isArray(selectedPlanConfig.os)
+            ? selectedPlanConfig.os
+            : [];
+
+          if (osList.length === 0) {
+            resolve({
+              status: "error",
+              plan: null,
+              message: `Plan ID ${plan.id} 没有可用的操作系统。`,
+            });
+            quickPick.hide();
+            return;
+          }
+
           items.push(
-            ...selectedPlanConfig.os.map((o: any) => ({
+            ...osList.map((o: any) => ({
               label: o.name,
               description: o.id.toString(),
               detail: " ",
@@ -312,8 +328,24 @@ export async function rebulidInstanceMultiStep(
             quickPick.hide();
             return; // 提前退出 updateView
           }
+
+          // 修复：确保 os 是数组，并且有数据
+          const osListRebuild = Array.isArray(selectedPlanConfig.os)
+            ? selectedPlanConfig.os
+            : [];
+
+          if (osListRebuild.length === 0) {
+            resolve({
+              status: "error",
+              rebulidInfo: null,
+              message: `Plan ID ${rebulidInfo.planId} 没有可用的操作系统。`,
+            });
+            quickPick.hide();
+            return;
+          }
+
           items.push(
-            ...selectedPlanConfig.os.map((o: any) => ({
+            ...osListRebuild.map((o: any) => ({
               label: o.name,
               description: o.id.toString(),
               detail: " ",


### PR DESCRIPTION
getPlanList接口不再返回plan.os一值，而当前代码错误地尝试该值，其将被解析为undefined。
后续的select代码因此不会工作，导致select os界面不显示操作系统。

此pr预期修复该问题，并在instanceMultiStep中添加对os.map的检查，确保存在可选择的目标os。