### PR TITLE
Properly check and notify EVO permission

### DIFF
--- a/src/alice/aliceService.ts
+++ b/src/alice/aliceService.ts
@@ -162,6 +162,30 @@ export class AliceService {
               }
             })
             .catch((error) => {
+              if (error.response && error.response.status === 400) {
+                this.dependencies
+                  .showErrorMessage(
+                    "请确认您的账户具有 EVO Cloud 权限。",
+                    "重试",
+                    "检查 Client ID/Secret",
+                    "打开 EVO Cloud 界面"
+                  )
+                  .then(async (selection) => {
+                    if (selection === "重试") {
+                      await this.updateConfig(flag);
+                    } else if (selection === "检查 Client ID/Secret") {
+                      this.dependencies.openSettings();
+                    } else if (selection === "打开 EVO Cloud 界面") {
+                      const vscode = require("vscode");
+                      vscode.env.openExternal(
+                        vscode.Uri.parse(
+                          "https://console.alice.sh/ephemera/evo-cloud"
+                        )
+                      );
+                    }
+                  });
+                return;
+              }
               console.error("Error fetching EVO permissions:", error);
             });
 

--- a/src/alice/aliceService.ts
+++ b/src/alice/aliceService.ts
@@ -179,7 +179,7 @@ export class AliceService {
                       await this.updateConfig(flag);
                     } else if (selection === "检查 Client ID/Secret") {
                       this.dependencies.openSettings();
-                    } else if (selection === "打开 EVO Cloud 界面") {
+                    } else if (selection === "访问 EVO Cloud 界面") {
                       const vscode = require("vscode");
                       vscode.env.openExternal(
                         vscode.Uri.parse(

--- a/src/alice/aliceService.ts
+++ b/src/alice/aliceService.ts
@@ -158,17 +158,21 @@ export class AliceService {
                   evoPermissions.allow_packages =
                     evoPermissions.allow_packages.split("|");
                 }
-                updateStateConfig({ evoPermissions: evoPermissions || {} }); // 更新状态
+                updateStateConfig({
+                  evoPermissions: evoPermissions || {},
+                  hasEvoPermission: true,
+                }); // 更新状态
               }
             })
             .catch((error) => {
               if (error.response && error.response.status === 400) {
+                updateStateConfig({ hasEvoPermission: false });
                 this.dependencies
                   .showErrorMessage(
-                    "请确认您的账户具有 EVO Cloud 权限。",
+                    "您的账户似乎没有 EVO Cloud 权限，请检查。",
                     "重试",
                     "检查 Client ID/Secret",
-                    "打开 EVO Cloud 界面"
+                    "访问 EVO Cloud 界面"
                   )
                   .then(async (selection) => {
                     if (selection === "重试") {
@@ -188,6 +192,10 @@ export class AliceService {
               }
               console.error("Error fetching EVO permissions:", error);
             });
+
+          if (!CONFIG.hasEvoPermission) {
+            return; // 如果没有 EVO 权限，停止后续操作
+          }
 
           // 获取计划列表
           await aliceApi

--- a/src/alice/config.ts
+++ b/src/alice/config.ts
@@ -94,6 +94,7 @@ export const CONFIG = {
   autoConnectInstanceHost: AUTO_CONNECT_INSTANCE_HOST,
   bootScriptPath: BOOT_SCRIPT_PATH,
   defaultPlan: DEFAULT_PLAN,
+  hasEvoPermission: false,
   evoPermissions: {} as any,
   instanceList: [] as any[],
   planList: [] as any[],

--- a/src/menu/index.ts
+++ b/src/menu/index.ts
@@ -105,7 +105,9 @@ export async function showCreateInstanceMenu() {
   const createItems: vscode.QuickPickItem[] = [
     {
       label: `$(refresh) 刷新配置`,
-      detail: "已创建实例，点击刷新配置",
+      detail: CONFIG.hasEvoPermission
+        ? "已创建实例,点击刷新配置"
+        : "重新检查 EVO 权限",
     },
     {
       label: `$(plus) 创建实例`,

--- a/src/menu/instanceMultiStep.ts
+++ b/src/menu/instanceMultiStep.ts
@@ -60,6 +60,24 @@ const backItem: vscode.QuickPickItem = {
 export async function createInstanceMultiStep(
   default_plan?: Plan
 ): Promise<CreateInstanceResult> {
+  // 检查是否有 EVO 权限
+  if (!CONFIG.hasEvoPermission) {
+    return {
+      status: "error",
+      plan: null,
+      message: "您的账户似乎没有 EVO Cloud 权限，无法创建实例。",
+    };
+  }
+
+  // 检查是否有可用的 Plan
+  if (!CONFIG.planList || CONFIG.planList.length === 0) {
+    return {
+      status: "error",
+      plan: null,
+      message: "没有可用的 Plan，请检查 EVO 权限或刷新配置。",
+    };
+  }
+
   const plan: Plan = default_plan || {
     id: NaN,
     os: NaN,

--- a/src/menu/instanceMultiStep.ts
+++ b/src/menu/instanceMultiStep.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import { Plan, RebuildInfo, CONFIG } from "../alice/config"; // 引入配置文件
 import { getScriptList } from "../utils/getScript";
+import { updateConfig } from "../commands";
 
 /**
  * 创建实例的状态机
@@ -65,12 +66,11 @@ export async function createInstanceMultiStep(
     const selection = await vscode.window.showErrorMessage(
       "您的账户似乎没有 EVO Cloud 权限,无法创建实例。",
       { modal: true },
-      "返回主界面",
       "重新检查权限"
     );
 
     if (selection === "重新检查权限") {
-      await vscode.commands.executeCommand("aliceephemera.updateConfig");
+      await updateConfig();
     }
 
     return {
@@ -85,12 +85,11 @@ export async function createInstanceMultiStep(
     const selection = await vscode.window.showErrorMessage(
       "没有可用的 Plan,请检查 EVO 权限或刷新配置。",
       { modal: true },
-      "返回主界面",
       "重新检查权限"
     );
 
     if (selection === "重新检查权限") {
-      await vscode.commands.executeCommand("aliceephemera.updateConfig");
+      await updateConfig();
     }
 
     return {

--- a/src/menu/instanceMultiStep.ts
+++ b/src/menu/instanceMultiStep.ts
@@ -62,19 +62,41 @@ export async function createInstanceMultiStep(
 ): Promise<CreateInstanceResult> {
   // 检查是否有 EVO 权限
   if (!CONFIG.hasEvoPermission) {
+    const selection = await vscode.window.showErrorMessage(
+      "您的账户似乎没有 EVO Cloud 权限,无法创建实例。",
+      { modal: true },
+      "返回主界面",
+      "重新检查权限"
+    );
+
+    if (selection === "重新检查权限") {
+      await vscode.commands.executeCommand("aliceephemera.updateConfig");
+    }
+
     return {
       status: "error",
       plan: null,
-      message: "您的账户似乎没有 EVO Cloud 权限，无法创建实例。",
+      message: "没有 EVO 权限",
     };
   }
 
   // 检查是否有可用的 Plan
   if (!CONFIG.planList || CONFIG.planList.length === 0) {
+    const selection = await vscode.window.showErrorMessage(
+      "没有可用的 Plan,请检查 EVO 权限或刷新配置。",
+      { modal: true },
+      "返回主界面",
+      "重新检查权限"
+    );
+
+    if (selection === "重新检查权限") {
+      await vscode.commands.executeCommand("aliceephemera.updateConfig");
+    }
+
     return {
       status: "error",
       plan: null,
-      message: "没有可用的 Plan，请检查 EVO 权限或刷新配置。",
+      message: "没有可用的 Plan",
     };
   }
 


### PR DESCRIPTION
当前插件没有正确处理没有evo权限的用户
evo plans接口对没有evo权限的用户开放
导致没有evo权限的用户能通过插件提交创建机器的请求（虽然不会成功）

此pr修复该问题，在初始化时正确提示，并阻止了无权限创建实例。

<img width="841" height="195" alt="image" src="https://github.com/user-attachments/assets/36324ca6-1831-4d85-99e6-afaeba1c5e37" />
<img width="1024" height="454" alt="image" src="https://github.com/user-attachments/assets/89f17fd3-4872-4155-a3f7-b515a3a900ad" />
